### PR TITLE
Correct fliter -> filter throughout

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ pains_filter requires the following packages:
 
 # Usage
 ### Parameters
-*   `fliter_pains` *(Required)* Apply PAINS filter to query compounds.
+*   `filter_pains` *(Required)* Apply PAINS filter to query compounds.
     *   `-q_mol, --query_file` *(Required)* The path of the input file that contains query compounds to be performed with PAINS filter.
     *   `-mod_file, --model_file` *(Required)* The path of the output file that contains result of Non-PAINS compounds.
+    

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A small tool to screen given virtual chemical libraries by the PAINS filter base
 # Requirements
 pains_filter requires the following packages:
 - rdkit (>=2019.09.x.x)
+- tqdm
 
 # Usage
 ### Parameters

--- a/pains_filter.py
+++ b/pains_filter.py
@@ -2,6 +2,7 @@ from rdkit import Chem
 from pathlib import Path
 import sys
 import argparse
+from tqdm import tqdm
 
 class PainsFilter(object):
     """
@@ -18,7 +19,7 @@ class PainsFilter(object):
         with open("./pains.txt", 'r') as _pains_substructure_smart:
             pains_substructures_smart = _pains_substructure_smart.readlines()
             self._pains_substructure_list = [Chem.MolFromSmarts(k) for k in pains_substructures_smart]
-        print (f"Number of PAINS substructure filters found: {len(self._pains_substructure_list)}")
+        print (f"The number of substructure fliters for PAINS: {len(self._pains_substructure_list)}")
     def _check_input(self, query_path:Path):
         """
         A private function used to check the type of the file containing query compounds.
@@ -54,7 +55,6 @@ class PainsFilter(object):
         """ 
         for ss in sub_list:
             if mol.HasSubstructMatch(ss):
-                print ("PAIN found")
                 return True
         return False
     def filter_by_pains(self, query_path:Path, result_path:Path, delimiter:str="\t", smiles_column:int=0, name_column:int=1):
@@ -86,18 +86,23 @@ class PainsFilter(object):
         else:
             suppl = Chem.SDMolSupplier(str(query_path))
         _cpd_without_pains_dict={}
+        n_pains_found=0
         print (f"Total number of query cpds for PAINS filter: {len(suppl)}")
-        for index, mol in enumerate(suppl):
-            if mol:
-                mol_addH = Chem.AddHs(mol) #Add hydrogen
-                if (self._pains_filt(mol_addH, self._pains_substructure_list) == False):
-                    _cpd_without_pains_dict[mol.GetProp("_Name")] = Chem.MolToSmiles(mol).strip()
-
-        print (f"Total number of cpds without PAINS: {len(_cpd_without_pains_dict)}")
         with open(str(result_path), 'w') as output:
-            for _cpd_name, _cpd_smiles in _cpd_without_pains_dict.items():
-                output.write(f"{_cpd_smiles.strip()}\t{_cpd_name.strip()}\n")
-
+            for mol in (pbar := tqdm(suppl, desc="Filtering pains", bar_format="{l_bar}{bar}{r_bar} PAINS found: {postfix} | Elapsed: {elapsed} | {rate_fmt}",postfix=n_pains_found,)):
+                if mol:
+                    mol_addH = Chem.AddHs(mol) #Add hydrogen
+                    if self._pains_filt(mol_addH, self._pains_substructure_list):
+                        n_pains_found+=1
+                        pbar.postfix=n_pains_found
+                        pbar.update()
+                    else:
+                        try:
+                            mol_title=mol.GetProp("_Name")
+                        except:
+                            mol_title=""
+                        output.write(f"{Chem.MolToSmiles(mol).strip()} {mol_title}\n")
+                        
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Filter molecules with PAINS")
     subparsers = parser.add_subparsers(dest= 'subcmd', help='subcommands', metavar='SUBCOMMAND')

--- a/pains_filter.py
+++ b/pains_filter.py
@@ -18,7 +18,7 @@ class PainsFilter(object):
         with open("./pains.txt", 'r') as _pains_substructure_smart:
             pains_substructures_smart = _pains_substructure_smart.readlines()
             self._pains_substructure_list = [Chem.MolFromSmarts(k) for k in pains_substructures_smart]
-        print (f"The number of substructure fliters for PAINS: {len(self._pains_substructure_list)}")
+        print (f"Number of PAINS substructure filters found: {len(self._pains_substructure_list)}")
     def _check_input(self, query_path:Path):
         """
         A private function used to check the type of the file containing query compounds.
@@ -103,12 +103,12 @@ if __name__ == "__main__":
     subparsers = parser.add_subparsers(dest= 'subcmd', help='subcommands', metavar='SUBCOMMAND')
     subparsers.required = True
 
-    parser_f1 = subparsers.add_parser("fliter_pains", help="Apply PAINS filter to query compounds")
+    parser_f1 = subparsers.add_parser("filter_pains", help="Apply PAINS filter to query compounds")
     parser_f1.add_argument("-q_mol", "--query_file", help="The path of the input file that contains query compounds to be performed with PAINS filter", dest= "infile", required=True)
     parser_f1.add_argument("-out", "--output_file", help="The path of the output file that contains result of Non-PAINS compounds", dest= "outfile", required=True)
     
     args = parser.parse_args()
     pains = PainsFilter()
 
-    if args.subcmd == "fliter_pains":
+    if args.subcmd == "filter_pains":
         pains.filter_by_pains(Path(args.infile), Path(args.outfile))


### PR DESCRIPTION
I attempted to use this and was met with command line arguments not being correct as it expected the subcommand 'f**li**ter_pains'.

Code changed throughout where 'fliter' appears, and changed to 'filter' along with the README.